### PR TITLE
Always close tabs when given or taken

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -451,7 +451,7 @@ class CommandDispatcher:
 
         self._open(tab.url(), tab=True)
         if not keep:
-            tabbed_browser.close_tab(tab, add_undo=False)
+            tabbed_browser.close_tab(tab, add_undo=False, transfer=True)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('win_id', completion=miscmodels.window)
@@ -500,7 +500,8 @@ class CommandDispatcher:
         tabbed_browser.tabopen(self._current_url())
         if not keep:
             self._tabbed_browser.close_tab(self._current_widget(),
-                                           add_undo=False)
+                                           add_undo=False,
+                                           transfer=True)
 
     def _back_forward(self, tab, bg, window, count, forward, index=None):
         """Helper function for :back/:forward."""

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -406,13 +406,14 @@ class TabbedBrowser(QWidget):
         else:
             yes_action()
 
-    def close_tab(self, tab, *, add_undo=True, new_undo=True):
+    def close_tab(self, tab, *, add_undo=True, new_undo=True, transfer=False):
         """Close a tab.
 
         Args:
             tab: The QWebView to be closed.
             add_undo: Whether the tab close can be undone.
             new_undo: Whether the undo entry should be a new item in the stack.
+            transfer: Whether the tab is closing because it is moving to a new window.
         """
         if config.val.tabs.tabs_are_windows:
             last_close = 'close'
@@ -421,13 +422,13 @@ class TabbedBrowser(QWidget):
 
         count = self.widget.count()
 
-        if last_close == 'ignore' and count == 1:
+        if last_close == 'ignore' and count == 1 and not transfer:
             return
 
         self._remove_tab(tab, add_undo=add_undo, new_undo=new_undo)
 
         if count == 1:  # We just closed the last tab above.
-            if last_close == 'close':
+            if last_close == 'close' or transfer:
                 self.close_window.emit()
             elif last_close == 'blank':
                 self.load_url(QUrl('about:blank'), newtab=True)


### PR DESCRIPTION
Add an optional boolean argument to `tabbed_browser.close_tab()` called
`transfer` which indicates whether the tab is closing as a result of
being given to another window (`tab-give`) or taken by another window
(`tab-take`). If so, the tab will always close, even if it is the last
tab in the window and `tabs.last_close` is not set to 'close'.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
